### PR TITLE
Always refresh CTA banner after starting hosted application

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,8 +37,7 @@
     "prettier": "3.5.3",
     "typescript": "~5.8.3",
     "typescript-eslint": "^8.30.1",
-    "vite": "^6.3.5",
-    "vite-bundle-analyzer": "^1.1.0"
+    "vite": "^6.3.5"
   },
   "optionalDependencies": {
     "@rollup/rollup-linux-x64-gnu": "4.9.5"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -81,9 +81,6 @@ importers:
       vite:
         specifier: ^6.3.5
         version: 6.3.5(sugarss@5.0.0(postcss@8.5.6))
-      vite-bundle-analyzer:
-        specifier: ^1.1.0
-        version: 1.1.0
     optionalDependencies:
       '@rollup/rollup-linux-x64-gnu':
         specifier: 4.9.5
@@ -1414,10 +1411,6 @@ packages:
   util-deprecate@1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
 
-  vite-bundle-analyzer@1.1.0:
-    resolution: {integrity: sha512-f/9m+6S5yPOHf/QS00rLOkyQ0icZeF67roM3O5LZZMPTOZFU1bHJTptNHCKMJc2yxXzj0Hunwcetrc+vM2LEQQ==}
-    hasBin: true
-
   vite@6.3.5:
     resolution: {integrity: sha512-cZn6NDFE7wdTpINgs++ZJ4N49W2vRp8LCKrn3Ob1kYNtOo21vfDoaV5GzBfLU4MovSAB8uNRm4jgzVQZ+mBzPQ==}
     engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
@@ -2719,8 +2712,6 @@ snapshots:
       '@types/react': 19.1.8
 
   util-deprecate@1.0.2: {}
-
-  vite-bundle-analyzer@1.1.0: {}
 
   vite@6.3.5(sugarss@5.0.0(postcss@8.5.6)):
     dependencies:

--- a/src/pages/dashboard.tsx
+++ b/src/pages/dashboard.tsx
@@ -88,19 +88,14 @@ export default function Dashboard({ scenario }: Props) {
           state: "US-CA",
           company_type: "LLC",
         },
-        user_data: {
-          first_name: "John",
-          last_name: "Doe",
-          email_address: "john.doe@example.com",
-          phone_number: "+1234567890",
-        },
+        user_data: {},
         partner_data: {},
       });
 
       if (isMockedMode) {
         sdk.setCtaResponse(CtaResponseTypes.CONTINUE_HOSTED_APPLICATION);
-        setCtaData(await sdk.getCta());
       }
+      setCtaData(await sdk.getCta());
 
       return startHostedApplicationResponse;
     }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,10 +1,9 @@
 import react from "@vitejs/plugin-react";
 import { defineConfig } from "vite";
-import { analyzer } from "vite-bundle-analyzer";
 
 // https://vite.dev/config/
 export default defineConfig({
-  plugins: [react(), analyzer()],
+  plugins: [react()],
   server: {
     host: "0.0.0.0",
     port: 5173,


### PR DESCRIPTION
- Noticed that the CTA banner wasn't being refreshed after starting a hosted application when in live mode, so fixed that
- Also removed the vite-bundle-analyzer from a few PRs ago; not needed any more